### PR TITLE
Fix path concatenation issue for cross compilers

### DIFF
--- a/clurp.nim
+++ b/clurp.nim
@@ -50,17 +50,17 @@ else:
     macro genCompile(moduleDir: static[string], paths: static[openarray[string]], includes: static[openarray[string]]): untyped =
         result = newNimNode(nnkStmtList)
         for p in paths:
-            let lit = newLit(moduleDir / p)
+            let lit = newLit((moduleDir / p).replace(DirSep, AltSep))
             result.add quote do:
                 {.compile: `lit`.}
 
         for i in includes:
-            let lit = newLit(i)
+            let lit = newLit(i.replace(DirSep, AltSep))
             result.add quote do:
                 {.passC: "-I" & `lit`.}
 
     template clurp*(paths: static[openarray[string]], includeDirs: static[openarray[string]] = [""]) =
-        const thisModuleDir = instantiationInfo(fullPaths = true).filename.parentDir()
+        const thisModuleDir = instantiationInfo(fullPaths = true).filename.parentDir().replace(DirSep, AltSep)
         genCompile(thisModuleDir, paths, includeDirs)
 
 when isMainModule:


### PR DESCRIPTION
I ran across a path concatenation issue when cross-compiling Nimx on Linux to Windows using MXE- for libwebp, the paths were partially using backslash and partially forward slash, resulting in jumbled paths that didn't work.

Replacing all path seperators with AltSep should only affect Windows systems (without having to do manual detection) and works fine there.